### PR TITLE
set $_SESSION['cartID']

### DIFF
--- a/includes/modules/payment/paypalwpp.php
+++ b/includes/modules/payment/paypalwpp.php
@@ -2828,10 +2828,13 @@ if (false) { // disabled until clarification is received about coupons in PayPal
         // restore cart contents
         $_SESSION['cart']->restore_contents();
         // eof: not require part of contents merge notice
-
+        $zc_check_basket_after = $_SESSION['cart']->count_contents();
+        if ($zc_check_basket_before > 0 && $zc_check_basket_before === $zc_check_basket_after) {
+            //  If contents still same set the cartID
+            $_SESSION['cartID'] = $_SESSION['cart']->cartID;
+        }
         // check current cart contents count if required
         if (SHOW_SHOPPING_CART_COMBINED > 0 && $zc_check_basket_before > 0) {
-          $zc_check_basket_after = $_SESSION['cart']->count_contents();
           if (($zc_check_basket_before != $zc_check_basket_after) && $_SESSION['cart']->count_contents() > 0 && SHOW_SHOPPING_CART_COMBINED > 0) {
             if (SHOW_SHOPPING_CART_COMBINED == 2) {
               // warning only do not send to cart


### PR DESCRIPTION
This fixes the issue where you go to the payment screen then back to the shipping screen as raised [on zen cart site]( https://github.com/zencart/zencart/pull/5060#issuecomment-1252552779 )

If you want me to change the zencart version rather than yours, please let me know and I do that.