### PR TITLE
Fix resolveTemplates() gating so it actually runs on the Template Selection opage

### DIFF
--- a/admin/template_select.php
+++ b/admin/template_select.php
@@ -16,6 +16,14 @@ if (isset($_GET['tID'])) {
 }
 
 $templateSelect = new TemplateSelect();
+
+// -----
+// This tool is the only place that needs the `template_select` table synchronized
+// with the templates currently found on the filesystem/installed via the Plugin
+// Manager, so it's the only caller responsible for triggering that (non-free)
+// synchronization; see TemplateSelect::resolveTemplates().
+//
+$templateSelect->resolveTemplates();
 $template_info = $templateSelect->getSelectableTemplates();
 
 $action = $_GET['action'] ?? '';

--- a/includes/classes/TemplateSelect.php
+++ b/includes/classes/TemplateSelect.php
@@ -83,18 +83,13 @@ class TemplateSelect
         }
 
         // -----
-        // Next, synchronize with the template-resolver since templates
-        // might have been removed or added from the file-system or disabled via
-        // the Plugin Manager.
+        // Note: Synchronizing with the template-resolver (to catch templates added,
+        // removed, or (re)enabled/disabled via the Plugin Manager since this class'
+        // static state was last populated) is NOT done here, since it involves a
+        // filesystem scan and potential DB writes on every construction. Callers that
+        // need that synchronization (currently, only the admin's "Template Selection"
+        // tool) must invoke resolveTemplates() explicitly; see admin/template_select.php.
         //
-        // This synchronization is run only during admin processing when the "Template
-        // Selection" tool is in use.
-        //
-        global $current_page;
-        if (IS_ADMIN_FLAG === true && $current_page === FILENAME_TEMPLATE_SELECT . '.php') {
-            $this->resolveTemplates();
-        }
-
         $active_template_dir = $this->getActiveTemplateDir();
         if ($active_template_dir !== null) {
             TemplateDto::getInstance()->updateTemplate($active_template_dir, ['is_active' => true]);
@@ -102,9 +97,19 @@ class TemplateSelect
     }
 
     /**
+     * Synchronizes the `template_select` table with the templates currently found on
+     * the filesystem (and installed via the Plugin Manager, for encapsulated
+     * template plugins), adding a 'base' (template_language = -1) record for any
+     * newly-discovered template directory.
+     *
+     * This involves a filesystem scan and potential DB writes, so it's not run
+     * automatically on every TemplateSelect construction (i.e. on every page load);
+     * callers that need it up to date (currently, only the admin's "Template
+     * Selection" tool) must call it explicitly.
+     *
      * @since ZC v3.0.0
      */
-    private function resolveTemplates(): void
+    public function resolveTemplates(): void
     {
         // -----
         // Determine which encapsulated plugins are currently installed,

--- a/not_for_release/testFramework/Unit/testsTemplateResolver/TemplateSelectSettingsPersistenceTest.php
+++ b/not_for_release/testFramework/Unit/testsTemplateResolver/TemplateSelectSettingsPersistenceTest.php
@@ -58,6 +58,7 @@ class TemplateSelectSettingsPersistenceTest extends zcUnitTestCase
     public function testSetTemplateSettingsPersistsAndIsRetrievable(): void
     {
         $templateSelect = new TemplateSelect();
+        $templateSelect->resolveTemplates();
 
         $status = $templateSelect->setTemplateSettings('responsive_classic', ['FOO' => 'bar']);
 
@@ -71,6 +72,7 @@ class TemplateSelectSettingsPersistenceTest extends zcUnitTestCase
     public function testSetTemplateSettingsReturnsUnknownDirForATemplateWithNoBaseRecord(): void
     {
         $templateSelect = new TemplateSelect();
+        $templateSelect->resolveTemplates();
 
         $status = $templateSelect->setTemplateSettings('not_a_real_template', ['FOO' => 'bar']);
 
@@ -81,6 +83,7 @@ class TemplateSelectSettingsPersistenceTest extends zcUnitTestCase
     public function testUpdateTemplateSettingsMergesWithExistingSettings(): void
     {
         $templateSelect = new TemplateSelect();
+        $templateSelect->resolveTemplates();
         $templateSelect->setTemplateSettings('responsive_classic', ['A' => '1', 'B' => '2']);
 
         $status = $templateSelect->updateTemplateSettings('responsive_classic', ['B' => '20', 'C' => '3']);
@@ -100,6 +103,7 @@ class TemplateSelectSettingsPersistenceTest extends zcUnitTestCase
     public function testTemplateSettingsSurviveDeregisteringTheActiveLanguageAssignment(): void
     {
         $templateSelect = new TemplateSelect();
+        $templateSelect->resolveTemplates();
         $templateSelect->setTemplateSettings('responsive_classic', ['THEME' => 'dark']);
 
         $newLanguageId = (int)$templateSelect->registerNewTemplate('responsive_classic', 5);
@@ -123,6 +127,7 @@ class TemplateSelectSettingsPersistenceTest extends zcUnitTestCase
     public function testRegisterNewTemplateRejectsAnAlreadyRegisteredLanguage(): void
     {
         $templateSelect = new TemplateSelect();
+        $templateSelect->resolveTemplates();
 
         $this->assertFalse(
             $templateSelect->registerNewTemplate('responsive_classic', 0),


### PR DESCRIPTION
The prior gating (IS_ADMIN_FLAG === true && $current_page === FILENAME_TEMPLATE_SELECT . '.php') never triggers in real usage: $current_page is set once during bootstrap from $PHP_SELF, which reflects admin/index.php (the front controller everything routes through via ?cmd=), never the cmd-dispatched sub-page. resolveTemplates() therefore never ran, leaving getSelectableTemplates()/ templateIsSelectable() always empty/false and breaking the New Template and Edit screens (confirmed via the real-DB TemplateSelectTest feature test, which regressed against this gating and now passes again).

Fix: make resolveTemplates() public and have admin/template_select.php call it explicitly, since that's the one place that unambiguously knows it's on the right page regardless of routing style. Updated TemplateSelectSettingsPersistenceTest to match.